### PR TITLE
feat: update debian/01dangerous-packages.conf

### DIFF
--- a/debian/01dangerous-packages.conf
+++ b/debian/01dangerous-packages.conf
@@ -23,6 +23,7 @@ APT {
     DangerousPackageWhitelist {
       "deepin-proxy";
       "deepin-system-fixpkg";
+      "deepin-systemassistant-knowledge";
       "deepin-screen-recorder-plugin";
       "deepin-dvsrv";
       "deepin-system-update";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+apt (2.8.0deepin9) unstable; urgency=medium
+
+  * update debian/01dangerous-packages.conf - Add deepin-systemassistant-
+    knowledge to DangerousPackageWhitelist
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 26 May 2026 21:34:01 +0800
+
 apt (2.8.0deepin8) unstable; urgency=medium
 
   * update debian/01dangerous-packages.conf. 


### PR DESCRIPTION
## Summary
- Add `deepin-systemassistant-knowledge` to DangerousPackageWhitelist
- Prevents the package from being flagged as dangerous during autoremove operations

## Test plan
1. Verify autoremove does not flag deepin-systemassistant-knowledge as dangerous
2. Verify deepin-systemassistant-knowledge is not removed during autoremove