### PR TITLE
feat: update debian/01dangerous-packages.conf

### DIFF
--- a/debian/01dangerous-packages.conf
+++ b/debian/01dangerous-packages.conf
@@ -8,6 +8,7 @@ APT {
     # These packages will trigger a warning when being removed during autoremove
     DangerousPackagePrefixes {
       "deepin-";
+      "com.deepin.";
       "dde-";
       "systemd";
       "xserver-";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+apt (2.8.0deepin10) unstable; urgency=medium
+
+  * update debian/01dangerous-packages.conf - Add com.deepin. prefix to
+    DangerousPackagePrefixes to cover reverse-domain-name packages
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 15 Jul 2026 11:00:00 +0800
+
 apt (2.8.0deepin9) unstable; urgency=medium
 
   * update debian/01dangerous-packages.conf - Add deepin-systemassistant-


### PR DESCRIPTION
Add com.deepin. prefix to DangerousPackagePrefixes to cover packages using reverse-domain-name convention (e.g. com.deepin.lianliankan, com.deepin.gomoku) — these were not matched by the existing deepin- prefix and therefore bypassed dangerous-package detection during autoremove

Log: Add com.deepin. prefix to dangerous package prefix list

Influence:
1. Verify autoremove flags com.deepin.lianliankan as dangerous
2. Verify autoremove flags com.deepin.gomoku as dangerous
3. Verify existing deepin- prefix packages still trigger correctly
4. Verify whitelisted packages (deepin-proxy, etc.) are not affected

feat: 更新 debian/01dangerous-packages.conf 危险包前缀

新增 com.deepin. 前缀以覆盖使用反向域名命名的包（如 com.deepin.lianliankan、 com.deepin.gomoku），这些包因不符合原 deepin- 前缀而绕过了自动删除时的
危险包检测

Log: 将 com.deepin. 添加到危险包前缀列表

Influence:
1. 验证 autoremove 会将 com.deepin.lianliankan 标记为危险包
2. 验证 autoremove 会将 com.deepin.gomoku 标记为危险包
3. 验证原有 deepin- 前缀包仍能正常触发检测
4. 验证白名单包（deepin-proxy 等）不受影响

repo: apt #master